### PR TITLE
Remove --save flag from gem install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Appwrite is an open-source backend as a service server that abstract and simplif
 To install via [Gem](https://rubygems.org/):
 
 ```bash
-gem install appwrite --save
+gem install appwrite
 ```
 
 


### PR DESCRIPTION
Closes #7 

Per https://github.com/appwrite/docs/pull/104 , the Ruby gem install command should not have the `--save` flag. This PR simply removes that flag from the `Readme.md` file so it can match the Appwrite Docs.

Note, I do still see the `--save` flag on the [Docs here](https://appwrite.io/docs/getting-started-for-server), so you may need to regenerate your Docs site?

Also, if this repo is Read Only, as it says in the About section, then please let me know where I can make this change upstream. Thank you! 👍 
