### PR TITLE
chore: bump SDK version to 24.2.0

### DIFF
--- a/appwrite.gemspec
+++ b/appwrite.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
 
   spec.name = 'appwrite'
-  spec.version = '24.1.0'
+  spec.version = '24.2.0'
   spec.license = 'BSD-3-Clause'
   spec.summary = 'Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API'
   spec.author = 'Appwrite Team'

--- a/lib/appwrite/client.rb
+++ b/lib/appwrite/client.rb
@@ -15,7 +15,7 @@ module Appwrite
                 'x-sdk-name'=> 'Ruby',
                 'x-sdk-platform'=> 'server',
                 'x-sdk-language'=> 'ruby',
-                'x-sdk-version'=> '24.1.0',
+                'x-sdk-version'=> '24.2.0',
                 'X-Appwrite-Response-Format' => '1.9.5'
             }
             @endpoint = 'https://cloud.appwrite.io/v1'


### PR DESCRIPTION
This PR bumps SDK version metadata to 24.2.0 after the concurrent chunk upload update.